### PR TITLE
Corrected stylesheet given in Glyph class docs

### DIFF
--- a/lib/src/components/glyph/glyph.dart
+++ b/lib/src/components/glyph/glyph.dart
@@ -19,7 +19,7 @@ import '../../model/ui/icon.dart';
 ///
 /// ```html
 /// <link rel="stylesheet" type="text/css"
-///     href="https://fonts.googleapis.com/icon?family=Material+Icons+Extended">
+///     href="https://fonts.googleapis.com/icon?family=Material+Icons">
 /// ```
 /// __Attributes:__
 ///


### PR DESCRIPTION
Address #10  (but doesn't fix not being able to use extended material icons). 